### PR TITLE
Add escape_pattern function to support magicchar indents

### DIFF
--- a/lua/nvim-cljfmt-indents.lua
+++ b/lua/nvim-cljfmt-indents.lua
@@ -502,6 +502,10 @@ local function get_indentation(buf, pos)
   return nil
 end
 
+function escape_pattern(text)
+  return text:gsub('(%W)', '%%%1')
+end
+
 function plugin.setup (opts)
   opts = opts or {}
   plugin.config = {}
@@ -533,7 +537,7 @@ function plugin.setup (opts)
         table.insert(indents,{
           priority = 0,
           matcher = function(s)
-            return (k == s or string.match(s, "/" .. k .. "$") or false) and true
+            return (k == s or string.match(s, "/" .. escape_pattern(k) .. "$") or false) and true
           end,
           rules = v
         })


### PR DESCRIPTION
A symbol can contain a magic character (\*, -, $, etc.) which will break the matching.  Add an escape to convert any non-alpha characters into %*, %-, etc. so this isn't a problem.

Fix #5 